### PR TITLE
Update regex to match Zoom's new URL pattern

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 function maybeClose(tabId, changeInfo, tab) {
-	if (tab.url.match(/https:\/\/([a-z]+).zoom.us\/[a-z]\/([0-9]+)\?(.*)?status=success/)) {
+	if (tab.url.match(/https:\/\/([a-z]+).zoom.us\/[a-z]\/([0-9]+)(\?(.*)?status=success|#success)/)) {
 		setTimeout(function() {
 			browser.tabs.remove(tab.id);
 		}, 2000);


### PR DESCRIPTION
The URL on the "success" page seems to have changed recently; it now has just an anchor `#success` instead of the query param (at least in my instance). This change should work for both old & new URLs.