### PR TITLE
Improved regex - account for #success

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 function maybeClose(tabId, changeInfo, tab) {
-	if (tab.url.match(/https:\/\/([a-z]+).zoom.us\/[a-z]\/([0-9]+)\?(.*)?status=success/)) {
+	if (tab.url.match(/https:\/\/([a-z]+).zoom.us\/[a-z]\/([0-9]+)\?(.*)(status=success|\#success)/)) {
 		setTimeout(function() {
 			browser.tabs.remove(tab.id);
 		}, 2000);


### PR DESCRIPTION
My URLS for meetings with a password look like this - https://company.zoom.us/j/<meeting_id>?pwd=<password_hash>#success

Note the #success at the end, not ?status=success. This update should accommodate for both cases. Tested here and works well.